### PR TITLE
fix: 카테고리가 비었을 때 빈 배열이 아닌 빈 객체를 받도록 수정

### DIFF
--- a/src/04-domain/entity/style.js
+++ b/src/04-domain/entity/style.js
@@ -22,7 +22,7 @@ export class Style {
     curationCount = 0,
     createdAt,
     updatedAt,
-    categories = [],
+    categories = {},
     tags = [],
     imageUrls = [],
   }) {


### PR DESCRIPTION
초반에 카테고리를 배열 형식으로 받아오게 코딩하여 값이 비었을 경우 빈 배열을 할당하는 코드가 있었음.
해당 코드를 확인하여 값이 비었을 경우 빈 객체가 할당되게끔 코드 수정.
확인 부탁드립니다.