### PR TITLE
fix: validator 내 content 길이 검증을 500자로 최신화

### DIFF
--- a/src/02-controller/req.validator/style/create.style.req.validator.js
+++ b/src/02-controller/req.validator/style/create.style.req.validator.js
@@ -49,7 +49,7 @@ export class CreateStyleValidator extends BaseValidator {
     if (title.length > 30) {
       throw new Exception(EXCEPTIONS.NOTICE_MAXTHREE);
     }
-    if (content.length > 300) {
+    if (content.length > 500) {
       throw new Exception(EXCEPTIONS.NOTICE_MAXHUND);
     }
     if (!/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,16}$/.test(password)) {

--- a/src/02-controller/req.validator/style/update.style.req.validator.js
+++ b/src/02-controller/req.validator/style/update.style.req.validator.js
@@ -54,7 +54,7 @@ export class UpdateStyleValidator extends BaseValidator {
     if (title.length > 30) {
       throw new Exception(EXCEPTIONS.NOTICE_MAXTHREE);
     }
-    if (content.length > 300) {
+    if (content.length > 500) {
       throw new Exception(EXCEPTIONS.NOTICE_MAXHUND);
     }
     if (!/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,16}$/.test(password)) {

--- a/src/05-repo/style.repo.js
+++ b/src/05-repo/style.repo.js
@@ -207,6 +207,7 @@ export class StyleRepo {
         _count: { select: { curations: true } },
       },
     });
+    
     return StyleMapper.toEntity(record);
   }
 


### PR DESCRIPTION
- 파일 확인 중에 style validator의 create와 update 검증 중, content 입력 제한 글자수가 최신화되지 않은 것을 확인하여 500으로 최신화하였습니다.

확인 부탁드립니다.